### PR TITLE
Add an icon when media has descriptions

### DIFF
--- a/app/javascript/mastodon/components/media_gallery.js
+++ b/app/javascript/mastodon/components/media_gallery.js
@@ -10,7 +10,7 @@ import { autoPlayGif, displaySensitiveMedia } from '../initial_state';
 
 const messages = defineMessages({
   toggle_visible: { id: 'media_gallery.toggle_visible', defaultMessage: 'Toggle visibility' },
-  described: { id: 'media_gallery.described', defaultMessage: 'Media descriptions present' },
+  described: { id: 'media_gallery.described', defaultMessage: 'Media description present' },
 });
 
 class Item extends React.PureComponent {

--- a/app/javascript/mastodon/components/media_gallery.js
+++ b/app/javascript/mastodon/components/media_gallery.js
@@ -10,7 +10,7 @@ import { autoPlayGif, displaySensitiveMedia } from '../initial_state';
 
 const messages = defineMessages({
   toggle_visible: { id: 'media_gallery.toggle_visible', defaultMessage: 'Toggle visibility' },
-  described: { id: 'media_gallery.described', defaultMessage: 'Media description present' },
+  described: { id: 'media_gallery.described', defaultMessage: 'Media description(s) present' },
 });
 
 class Item extends React.PureComponent {

--- a/app/javascript/mastodon/components/media_gallery.js
+++ b/app/javascript/mastodon/components/media_gallery.js
@@ -10,6 +10,7 @@ import { autoPlayGif, displaySensitiveMedia } from '../initial_state';
 
 const messages = defineMessages({
   toggle_visible: { id: 'media_gallery.toggle_visible', defaultMessage: 'Toggle visibility' },
+  described: { id: 'media_gallery.described', defaultMessage: 'Media descriptions present' },
 });
 
 class Item extends React.PureComponent {
@@ -231,6 +232,21 @@ export default class MediaGallery extends React.PureComponent {
     const { media, intl, sensitive, height } = this.props;
     const { width, visible } = this.state;
 
+    let described = [];
+    if (media.take(4).some((attachment, i) => attachment.get("description"))) {
+      const fontSize = 18;
+      const describedIconStyle = {
+        fontSize: `${fontSize}px`,
+        width: `${fontSize * 1.28571429}px`,
+        height: `${fontSize * 1.28571429}px`,
+        lineHeight: `${fontSize}px`,
+      };
+      described = (<div className='media-gallery__described' title={intl.formatMessage(messages.described)} aria-hidden='true'>
+          <div className='media-gallery__described-icon-wrapper' style={describedIconStyle}><i className='fa fa-fw fa-universal-access' /></div>
+        </div>
+      );
+    }
+
     let children;
 
     const style = {};
@@ -275,6 +291,8 @@ export default class MediaGallery extends React.PureComponent {
         <div className={classNames('spoiler-button', { 'spoiler-button--visible': visible })}>
           <IconButton title={intl.formatMessage(messages.toggle_visible)} icon={visible ? 'eye' : 'eye-slash'} overlay onClick={this.handleOpen} />
         </div>
+
+        {described}
 
         {children}
       </div>

--- a/app/javascript/mastodon/components/media_gallery.js
+++ b/app/javascript/mastodon/components/media_gallery.js
@@ -234,15 +234,9 @@ export default class MediaGallery extends React.PureComponent {
 
     let described = [];
     if (media.take(4).some((attachment, i) => attachment.get("description"))) {
-      const fontSize = 18;
-      const describedIconStyle = {
-        fontSize: `${fontSize}px`,
-        width: `${fontSize * 1.28571429}px`,
-        height: `${fontSize * 1.28571429}px`,
-        lineHeight: `${fontSize}px`,
-      };
-      described = (<div className='media-gallery__described' title={intl.formatMessage(messages.described)} aria-hidden='true'>
-          <div className='media-gallery__described-icon-wrapper' style={describedIconStyle}><i className='fa fa-fw fa-universal-access' /></div>
+      described = (
+        <div className='media-gallery__described' aria-hidden='true'>
+          <IconButton title={intl.formatMessage(messages.described)} icon='universal-access' overlay />
         </div>
       );
     }

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -155,6 +155,7 @@
   "lists.search": "Search among people you follow",
   "lists.subheading": "Your lists",
   "loading_indicator.label": "Loading...",
+  "media_gallery.described": "Media descriptions present",
   "media_gallery.toggle_visible": "Toggle visibility",
   "missing_indicator.label": "Not found",
   "missing_indicator.sublabel": "This resource could not be found",

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2874,15 +2874,6 @@ a.status-card {
   z-index: 100;
 }
 
-.media-gallery__described-icon-wrapper {
-  box-sizing: content-box;
-  background: rgba($base-overlay-background, 0.6);
-  color: rgba($primary-text-color, 0.7);
-  border-radius: 4px;
-  padding: 2px;
-  margin: auto;
-}
-
 .modal-container--preloader {
   background: lighten($ui-base-color, 8%);
 }

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2867,6 +2867,22 @@ a.status-card {
   }
 }
 
+.media-gallery__described {
+  position: absolute;
+  top: 4px;
+  left: 35px;
+  z-index: 100;
+}
+
+.media-gallery__described-icon-wrapper {
+  box-sizing: content-box;
+  background: rgba($base-overlay-background, 0.6);
+  color: rgba($primary-text-color, 0.7);
+  border-radius: 4px;
+  padding: 2px;
+  margin: auto;
+}
+
 .modal-container--preloader {
   background: lighten($ui-base-color, 8%);
 }


### PR DESCRIPTION
Following [this conversation](https://mspsocial.net/@lawremipsum/100669128750549921), here's an implementation of an icon that indicates whether media has accessible descriptions or not. I went with Font Awesome's universal access icon. See below for a screenshot of the feature in action. The icon appears when at least one item in a media gallery has a description, and the icon does not appear if none of the media has descriptions. I tagged the whole thing as `aria-hidden="true"`, because I figure there's no point in a screen reader telling you there's an image description before it actually tells you the description itself.

I'm not 100% happy with the CSS, because the icon isn't vertically aligned inside the background box. I believe this is a result of me using a `<div>` where the adjacent icon uses a `<button>`. I don't want to use a `<button>`, because nothing happens when you click on the icon, but at the same time, I don't know how to replicate the vertical centering.

I'm definitely open to input on this and anything else, what do y'all think?

![screen shot 2018-09-05 at 06 50 41-fullpage](https://user-images.githubusercontent.com/181772/45092026-cf78ea80-b0d9-11e8-8e30-768882b1b035.png)

Fixes #11