### PR TITLE
Add an "ope" to the streaming API errors

### DIFF
--- a/app/javascript/mastodon/actions/alerts.js
+++ b/app/javascript/mastodon/actions/alerts.js
@@ -41,7 +41,7 @@ export function showAlertForError(error) {
       message = data.error;
     }
 
-    return showAlert(title, message);
+    return showAlert(title, `Ope! ${message}`);
   } else {
     console.error(error);
     return showAlert(messages.unexpectedTitle, messages.unexpectedMessage);

--- a/app/javascript/mastodon/actions/alerts.js
+++ b/app/javascript/mastodon/actions/alerts.js
@@ -41,7 +41,7 @@ export function showAlertForError(error) {
       message = data.error;
     }
 
-    return showAlert(title, `Ope! ${message}`);
+    return showAlert('Ope!', `${title}: ${message}`);
   } else {
     console.error(error);
     return showAlert(messages.unexpectedTitle, messages.unexpectedMessage);

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -35,7 +35,7 @@
   "account.unmute_notifications": "Unmute notifications from @{name}",
   "account.view_full_profile": "View full profile",
   "alert.unexpected.message": "An unexpected error occurred.",
-  "alert.unexpected.title": "Oops!",
+  "alert.unexpected.title": "Ope!",
   "boost_modal.combo": "You can press {combo} to skip this next time",
   "bundle_column_error.body": "Something went wrong while loading this component.",
   "bundle_column_error.retry": "Try again",


### PR DESCRIPTION
Per [this request thread](https://mspsocial.net/@lawremipsum/100682070844292340), adds an "ope" to the front of all HTTP errors coming from the streaming API.

~~Things I haven't done:~~

 * ~~Actually tested this to see if it works. Sorry! Someday I will get a Mastodon dev environment set up, but today is not that day.~~